### PR TITLE
[WIP] implement version up check with -u option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 
 == USAGE
 
-    Usage: gobump (major|minor|patch|set <version>) [-w] [-v] [<path>]
+    Usage: gobump (major|minor|patch|set <version>|show) [-w] [-v] [-u] [<path>]
 
     Commands:
       major             bump major version up
@@ -14,8 +14,10 @@
       show              only show the versions (implies -v)
 
     Flags:
-      -v=false: show the resulting version values
-      -w=false: write result to (source) file instead of stdout
+      -r    output in raw text instead of JSON when output exists
+      -u    ensure version up with the set command
+      -v    show the resulting version values
+      -w    write result to (source) file instead of stdout
 
 == EXAMPLE
 

--- a/cli.go
+++ b/cli.go
@@ -20,7 +20,7 @@ func Run(argv []string, outStream, errStream io.Writer) error {
 	fs.Usage = func() {
 		out := errStream
 		fs.SetOutput(out)
-		fmt.Fprintln(out, `Usage: gobump (major|minor|patch|set <version>) [-w] [-v] [<path>]
+		fmt.Fprintln(out, `Usage: gobump (major|minor|patch|set <version>|show) [-w] [-v] [-u] [<path>]
 
 Commands:
   major             bump major version up

--- a/cli.go
+++ b/cli.go
@@ -11,10 +11,12 @@ func Run(argv []string, outStream, errStream io.Writer) error {
 	gb := &Gobump{
 		OutStream: outStream,
 	}
+	var checkVersionUp bool
 	fs := flag.NewFlagSet("gobump", flag.ContinueOnError)
 	fs.BoolVar(&gb.Write, "w", false, "write result to (source) file instead of stdout")
 	fs.BoolVar(&gb.Verbose, "v", false, "show the resulting version values")
 	fs.BoolVar(&gb.Raw, "r", false, "output in raw text instead of JSON when output exists")
+	fs.BoolVar(&checkVersionUp, "u", false, "ensure version up with the set command")
 	fs.Usage = func() {
 		out := errStream
 		fs.SetOutput(out)
@@ -58,6 +60,7 @@ Flags:`)
 	if err := fs.Parse(argv[parseOffset:]); err != nil {
 		return err
 	}
+	gb.Config.CheckVersionUp = checkVersionUp
 
 	gb.Target = fs.Arg(0)
 	_, err := gb.Run()

--- a/gobump.go
+++ b/gobump.go
@@ -111,6 +111,8 @@ type Config struct {
 	PatchDelta uint64
 	// Sets the version to exact version (no bump). Precedes all of above delta's.
 	Exact string
+	// Return an error when the exact version is not greater than the current version.
+	CheckVersionUp bool
 	// The pattern of "version" variable/constants. Defaults to /^(?i)version$/.
 	NamePattern *regexp.Regexp
 	// Default version in the case none was set. Defaults to "0.0.0".
@@ -250,6 +252,14 @@ func (conf Config) bumpedVersion(version string) (string, error) {
 		exact, err := semver.New(conf.Exact)
 		if err != nil {
 			return "", err
+		}
+
+		if conf.CheckVersionUp {
+			if v, err := semver.Parse(version); err == nil {
+				if !exact.GT(v) {
+					return "", fmt.Errorf("version %s is not greater than the current version", exact)
+				}
+			}
 		}
 
 		return exact.String(), nil

--- a/gobump_test.go
+++ b/gobump_test.go
@@ -39,3 +39,101 @@ func TestBump(t *testing.T) {
 		}
 	}
 }
+
+func TestBumpedVersion(t *testing.T) {
+	testCases := []struct {
+		name            string
+		conf            Config
+		currentVersion  string
+		expectedVersion string
+		expectedError   bool
+	}{
+		{
+			name:            "major delta",
+			conf:            Config{MajorDelta: 2},
+			currentVersion:  "1.2.3",
+			expectedVersion: "3.0.0",
+		},
+		{
+			name:            "minor delta",
+			conf:            Config{MinorDelta: 2},
+			currentVersion:  "1.2.3",
+			expectedVersion: "1.4.0",
+		},
+		{
+			name:            "patch delta",
+			conf:            Config{PatchDelta: 2},
+			currentVersion:  "1.2.3",
+			expectedVersion: "1.2.5",
+		},
+		{
+			name:            "exact version",
+			conf:            Config{Exact: "2.3.4"},
+			currentVersion:  "1.2.3",
+			expectedVersion: "2.3.4",
+		},
+		{
+			name:           "invalid exact version",
+			conf:           Config{Exact: "xxx"},
+			currentVersion: "1.2.3",
+			expectedError:  true,
+		},
+		{
+			name:            "version bump down",
+			conf:            Config{Exact: "0.1.2"},
+			currentVersion:  "1.2.3",
+			expectedVersion: "0.1.2",
+		},
+		{
+			name:            "check patch version up",
+			conf:            Config{Exact: "1.2.4", CheckVersionUp: true},
+			currentVersion:  "1.2.3",
+			expectedVersion: "1.2.4",
+		},
+		{
+			name:            "check minor version up",
+			conf:            Config{Exact: "1.3.0", CheckVersionUp: true},
+			currentVersion:  "1.2.3",
+			expectedVersion: "1.3.0",
+		},
+		{
+			name:            "check major version up",
+			conf:            Config{Exact: "2.0.0", CheckVersionUp: true},
+			currentVersion:  "1.2.3",
+			expectedVersion: "2.0.0",
+		},
+		{
+			name:           "error on bump down",
+			conf:           Config{Exact: "1.2.2", CheckVersionUp: true},
+			currentVersion: "1.2.3",
+			expectedError:  true,
+		},
+		{
+			name:           "error on same version",
+			conf:           Config{Exact: "1.2.3", CheckVersionUp: true},
+			currentVersion: "1.2.3",
+			expectedError:  true,
+		},
+		{
+			name:            "set from empty",
+			conf:            Config{Exact: "0.1.2", CheckVersionUp: true},
+			currentVersion:  "",
+			expectedVersion: "0.1.2",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.conf.bumpedVersion(tc.currentVersion)
+			if got != tc.expectedVersion {
+				t.Errorf("expected %v: got %v", tc.expectedVersion, got)
+			}
+			if (err != nil) != tc.expectedError {
+				if tc.expectedError {
+					t.Errorf("expected an error but got no error")
+				} else {
+					t.Errorf("expected no error but got an error: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
I added a new option `-u` to ensure the version up with `set` subcommand. This is useful to prevent some accidents in the release flow.

```bash
 $ gobump set 0.0.9 -w -u cli/
cli/cli.go:15:7: version bump failed: version 0.0.9 is not greater than the current version: "0.1.0"
```